### PR TITLE
rewire provisioners for config override

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = uctt
-version = 0.3.2
+version = 0.4.0
 description = Universal cluster testing toolkit
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -37,7 +37,7 @@ packages =
     uctt.contrib.terraform
 include_package_data = True
 install_requires =
-    configerus>=0.2.4
+    configerus>=0.2.5
     pyyaml
     docker
     kubernetes==17.14.0a1

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ packages =
     uctt.contrib.terraform
 include_package_data = True
 install_requires =
-    configerus>=0.2.5
+    configerus>=0.3.0
     pyyaml
     docker
     kubernetes==17.14.0a1

--- a/uctt/__init__.py
+++ b/uctt/__init__.py
@@ -160,6 +160,8 @@ def new_provisioner_from_config(config: Config,
     the module that contains the factory method with a decorator.
 
     """
+    logger.debug("Creating provisioner: [{}]:[{}][{}] : {}".format(
+        label, key, instance_id, config.load(label).get(key)))
     return new_plugin_from_config(
         config=config, type=Type.PROVISIONER, label=label, key=key)
 

--- a/uctt/__init__.py
+++ b/uctt/__init__.py
@@ -17,16 +17,28 @@ import logging
 
 from configerus.config import Config
 from configerus.loaded import LOADED_KEY_ROOT
-from configerus.contrib.dict import PLUGIN_ID_SOURCE_DICT
 
 from .plugin import Type
 from .instances import PluginInstances
 from .constructors import new_plugins_from_config, new_plugins_from_dict, new_plugin_from_config, new_plugin_from_dict, new_plugin
-from .provisioner import ProvisionerBase
-from .workload import WorkloadBase
-from .client import ClientBase
-from .output import OutputBase
+from .provisioner import (
+    ProvisionerBase,
+    UCTT_PROVISIONER_CONFIG_PROVISIONERS_LABEL,
+    UCTT_PROVISIONER_CONFIG_PROVISIONER_LABEL)
+from .client import (
+    ClientBase,
+    UCTT_CLIENT_CONFIG_CLIENTS_LABEL,
+    UCTT_CLIENT_CONFIG_CLIENT_LABEL)
+from .output import (
+    OutputBase,
+    UCTT_OUTPUT_CONFIG_OUTPUTS_LABEL,
+    UCTT_OUTPUT_CONFIG_OUTPUT_LABEL)
+from .workload import (
+    WorkloadBase,
+    UCTT_WORKLOAD_CONFIG_WORKLOADS_LABEL,
+    UCTT_WORKLOAD_CONFIG_WORKLOAD_LABEL)
 
+# make sure that the common factory decorators are run
 import uctt.contrib.common
 
 logger = logging.getLogger('uctt')
@@ -96,19 +108,10 @@ def bootstrap(config: Config, bootstraps=[]):
 
 """ PROVISIONER CONSTRUCTION """
 
-UCTT_PROVISIONERS_CONFIG_LABEL = 'provisioners'
-""" provisioners_from_config will load this config to decide how to build provisioner plugins """
-UCTT_PROVISIONERS_CONFIG_KEY_PROVISIONERS = LOADED_KEY_ROOT
-""" default loaded config get key for provisioners in UCTT_PROVISIONERS_CONFIG_LABEL """
-UCTT_PROVISIONER_CONFIG_LABEL = 'provisioner'
-""" default config label which should define a single provisioner """
-UCTT_PROVISIONER_CONFIG_KEY_PROVISIONER = '.'
-""" default loaded config get key for provisioner settings in UCTT_PROVISIONER_CONFIG_LABEL """
-
 
 def new_provisioners_from_config(config: Config,
-                                 label: str = UCTT_PROVISIONERS_CONFIG_LABEL,
-                                 base: str = UCTT_PROVISIONERS_CONFIG_KEY_PROVISIONERS) -> PluginInstances:
+                                 label: str = UCTT_PROVISIONER_CONFIG_PROVISIONERS_LABEL,
+                                 base: Any = LOADED_KEY_ROOT) -> PluginInstances:
     """ Create provisioners from some config
 
     This method will interpret some config values as being usable to build
@@ -124,7 +127,11 @@ def new_provisioners_from_config(config: Config,
     label (str) : config label to load to pull provisioner configuration. That
         label is loaded and config is pulled to produce a list of provisioners
 
-    base (str) : config key to get a Dict of provisioners configurations.
+    base (str|List) : config key to get a Dict of plugins configurations.
+        A list of strings is valid as configerus.loaded.get() can take that as
+        an argument.
+        We call this base instead of key as we will be searching for sub-paths
+        to pull individual elements
 
     Returns:
     --------
@@ -144,8 +151,8 @@ def new_provisioners_from_config(config: Config,
         config=config, type=Type.PROVISIONER, label=label, base=base)
 
 
-def new_provisioner_from_config(config: Config, label: str = UCTT_PROVISIONER_CONFIG_LABEL,
-                                base: str = UCTT_PROVISIONER_CONFIG_KEY_PROVISIONER, instance_id: str = '') -> ProvisionerBase:
+def new_provisioner_from_config(config: Config, label: str = UCTT_PROVISIONER_CONFIG_PROVISIONER_LABEL,
+                                base: Any = LOADED_KEY_ROOT, instance_id: str = '') -> ProvisionerBase:
     """ Create a provisioner from some config
 
     This method will interpret some config values as being usable to build a
@@ -159,7 +166,11 @@ def new_provisioner_from_config(config: Config, label: str = UCTT_PROVISIONER_CO
     label (str) : config label to load to pull provisioner configuration. That
         label is loaded and config is pulled to produce a list of provisioners
 
-    base (str) : config key to get a Dict of provisioners configurations.
+    base (str|List) : config key to get a Dict of plugin configuration.
+        A list of strings is valid as configerus.loaded.get() can take that as
+        an argument.
+        We call this base instead of key as we will be searching for sub-paths
+        to pull individual elements
 
     instance_id (str) : optionally force a particular instance_id to be assigned
 
@@ -177,8 +188,9 @@ def new_provisioner_from_config(config: Config, label: str = UCTT_PROVISIONER_CO
     the module that contains the factory method with a decorator.
 
     """
-    logger.debug("Creating provisioner: [{}]:[{}][{}]".format(
-        label, base, instance_id))
+    logger.debug(
+        "Creating provisioner: [{}]:[{}][{}]".format(
+            label, base, instance_id))
     return new_plugin_from_config(
         config=config, type=Type.PROVISIONER, label=label, base=base)
 
@@ -269,19 +281,10 @@ def new_provisioner(config: Config, plugin_id: str,
 
 """ CLIENT CONSTRUCTION """
 
-UCTT_CLIENTS_CONFIG_LABEL = 'clients'
-""" clients_from_config will load this config to decide how to build client plugins """
-UCTT_CLIENTS_CONFIG_KEY_CLIENTS = '.'
-""" default loaded config get key for clients in UCTT_CLIENTS_CONFIG_LABEL """
-UCTT_CLIENT_CONFIG_LABEL = 'client'
-""" default config label which should define a single client """
-UCTT_CLIENT_CONFIG_KEY_CLIENT = '.'
-""" default loaded config get key for client settings in UCTT_CLIENT_CONFIG_LABEL """
-
 
 def new_clients_from_config(config: Config,
-                            label: str = UCTT_CLIENTS_CONFIG_LABEL,
-                            base: str = UCTT_CLIENTS_CONFIG_KEY_CLIENTS) -> PluginInstances:
+                            label: str = UCTT_CLIENT_CONFIG_CLIENTS_LABEL,
+                            base: Any = LOADED_KEY_ROOT) -> PluginInstances:
     """ Create clients from some config
 
     This method will interpret some config values as being usable to build
@@ -295,7 +298,11 @@ def new_clients_from_config(config: Config,
     label (str) : config label to load to pull client configuration. That
         label is loaded and config is pulled to produce a list of clients
 
-    base (str) : config key to get a Dict of clients configurations.
+    base (str|List) : config key to get a Dict of plugins configurations.
+        A list of strings is valid as configerus.loaded.get() can take that as
+        an argument.
+        We call this base instead of key as we will be searching for sub-paths
+        to pull individual elements
 
     Returns:
     --------
@@ -316,8 +323,8 @@ def new_clients_from_config(config: Config,
 
 
 def new_client_from_config(config: Config,
-                           label: str = UCTT_CLIENT_CONFIG_LABEL,
-                           base: str = UCTT_CLIENT_CONFIG_KEY_CLIENT) -> ClientBase:
+                           label: str = UCTT_CLIENT_CONFIG_CLIENT_LABEL,
+                           base: Any = LOADED_KEY_ROOT) -> ClientBase:
     """ Create a client from some config
 
     This method will interpret some config values as being usable to build a
@@ -331,7 +338,11 @@ def new_client_from_config(config: Config,
     label (str) : config label to load to pull client configuration. That
         label is loaded and config is pulled to produce a list of clients
 
-    base (str) : config key to get a Dict of clients configurations.
+    base (str|List) : config key to get a Dict of plugin configuration.
+        A list of strings is valid as configerus.loaded.get() can take that as
+        an argument.
+        We call this base instead of key as we will be searching for sub-paths
+        to pull individual elements
 
     Returns:
     --------
@@ -432,353 +443,12 @@ def new_client(config: Config, plugin_id: str, instance_id: str) -> ClientBase:
                       plugin_id=plugin_id, instance_id=instance_id)
 
 
-""" WORKLOAD CONSTRUCTION """
-
-UCTT_WORKLOADS_CONFIG_LABEL = 'workloads'
-""" workloads_from_config will load this config to decide how to build workload plugins """
-UCTT_WORKLOADS_CONFIG_KEY_WORKLOADS = '.'
-""" default loaded config get key for workloads in UCTT_WORKLOADS_CONFIG_LABEL """
-UCTT_WORKLOAD_CONFIG_LABEL = 'workload'
-""" default config label which should define a single workload """
-UCTT_WORKLOAD_CONFIG_KEY_WORKLOAD = '.'
-""" default loaded config get key for workload settings in UCTT_WORKLOAD_CONFIG_LABEL """
-
-
-def new_workloads_from_config(config: Config,
-                              label: str = UCTT_WORKLOADS_CONFIG_LABEL,
-                              base: str = UCTT_WORKLOADS_CONFIG_KEY_WORKLOADS) -> PluginInstances:
-    """ Create workloads from some config
-
-    This method will interpret some config values as being usable to build
-    a PluginInstances set of workload plugins
-
-    Parameters:
-    -----------
-
-    config (Config) : Used to load and get the workload configuration
-
-    label (str) : config label to load to pull workload configuration. That
-        label is loaded and config is pulled to produce a list of workloads
-
-    base (str) : config key to get a Dict of workloads configurations.
-
-    Returns:
-    --------
-
-    PluginInstances of workload plugins
-
-    Raises:
-    -------
-
-    If you ask for a plugin which has not been registered, then you're going to
-    get a NotImplementedError exception.
-    To make sure that your desired plugin is registered, make sure to import
-    the module that contains the factory method with a decorator.
-
-    """
-    return new_plugins_from_config(
-        config=config, type=Type.WORKLOAD, label=label, base=base)
-
-
-def new_workload_from_config(config: Config,
-                             label: str = UCTT_WORKLOAD_CONFIG_LABEL,
-                             base: str = UCTT_WORKLOAD_CONFIG_KEY_WORKLOAD) -> WorkloadBase:
-    """ Create a workload from some config
-
-    This method will interpret some config values as being usable to build
-    workload
-
-    Parameters:
-    -----------
-
-    config (Config) : Used to load and get the workload configuration
-
-    label (str) : config label to load to pull workload configuration. That
-        label is loaded and config is pulled to produce a list of workloads
-
-    base (str) : config key to get a Dict of workloads configurations.
-
-    Returns:
-    --------
-
-    workload plugin (WorkloadBase)
-
-    Raises:
-    -------
-
-    If you ask for a plugin which has not been registered, then you're going to
-    get a NotImplementedError exception.
-    To make sure that your desired plugin is registered, make sure to import
-    the module that contains the factory method with a decorator.
-
-    """
-    return new_plugin_from_config(
-        config=config, type=Type.WORKLOAD, label=label, base=base)
-
-
-def new_workloads_from_dict(
-        config: Config, workload_list: Dict[str, Dict]) -> PluginInstances:
-    """ Create a set of workload plugins from Dict information
-
-    The passed dict should be a key=>details map of workloads, which will be turned
-    into a PluginInstances map of plugins that can be used to interact with the
-    objects.
-
-    Parameters:
-    -----------
-
-    config (Config) : configerus.Config object passed to each generated plugins.
-
-    workload_list (Dict[str, Dict]) : map of key=> config dicts, where each dict
-        contains all of the information that is needed to build the plugin.
-
-        for details, @see new_plugins_from_dict
-
-    Returns:
-    --------
-
-    A PluginsInstances object with the plugin objects created
-
-    """
-    return new_plugins_from_dict(
-        config=config, type=Type.WORKLOAD, plugin_list=workload_list)
-
-
-def new_workload_from_dict(
-        config: Config, workload_dict: Dict[str, Any]) -> WorkloadBase:
-    """ Create a single workload plugin from a Dict of information for it
-
-    Create a new workload plugin from a map/dict of settings for the needed parameters.
-
-    Parameters:
-    -----------
-
-    config (Config) : configerus.Config object passed to each generated plugins.
-
-    workload_dict (Dict[str,Any]) : Dict from which all needed information will
-        be pulled.  Optionally additional config sources can be included as well
-        as arguments which could be passed to the plugin.
-
-        @see new_plugin_from_dict for more details.
-
-    Return:
-    -------
-
-    A plugin object (WorkloadBase)
-
-    """
-    return new_plugin_from_dict(
-        config=config, type=Type.WORKLOAD, plugin_dict=workload_dict)
-
-
-def new_workload(config: Config, plugin_id: str,
-                 instance_id: str) -> WorkloadBase:
-    """ Create a new workload from parameters
-
-    Parameters:
-    -----------
-
-    config (Config) : configerus.Config object passed to each generated plugins.
-
-    plugin_id (str) : UCTT plugin id for the workload type, to tell us what plugin
-        factory to load.
-
-        @see .plugin.Factory for more details on how plugins are loaded.
-
-    instance_id (str) : string instance id that will be passed to the new plugin
-        object.
-
-    Return:
-    -------
-
-    A plugin object (WorkloadBase)
-
-    """
-    return new_plugin(config=config, type=Type.WORKLOAD,
-                      plugin_id=plugin_id, instance_id=instance_id)
-
-
-""" WORKLOAD CONSTRUCTION """
-
-UCTT_WORKLOADS_CONFIG_LABEL = 'workloads'
-""" workloads_from_config will load this config to decide how to build workload plugins """
-UCTT_WORKLOADS_CONFIG_KEY_WORKLOADS = '.'
-""" default loaded config get key for workloads in UCTT_WORKLOADS_CONFIG_LABEL """
-UCTT_WORKLOAD_CONFIG_LABEL = 'workload'
-""" default config label which should define a single workload """
-UCTT_WORKLOAD_CONFIG_KEY_WORKLOAD = '.'
-""" default loaded config get key for workload settings in UCTT_WORKLOAD_CONFIG_LABEL """
-
-
-def new_workloads_from_config(config: Config,
-                              label: str = UCTT_WORKLOADS_CONFIG_LABEL,
-                              base: str = UCTT_WORKLOADS_CONFIG_KEY_WORKLOADS) -> PluginInstances:
-    """ Create workloads from some config
-
-    This method will interpret some config values as being usable to build
-    a PluginInstances set of workload plugins
-
-    Parameters:
-    -----------
-
-    config (Config) : Used to load and get the workload configuration
-
-    label (str) : config label to load to pull workload configuration. That
-        label is loaded and config is pulled to produce a list of workloads
-
-    base (str) : config key to get a Dict of workloads configurations.
-
-    Returns:
-    --------
-
-    PluginInstances of workload plugins
-
-    Raises:
-    -------
-
-    If you ask for a plugin which has not been registered, then you're going to
-    get a NotImplementedError exception.
-    To make sure that your desired plugin is registered, make sure to import
-    the module that contains the factory method with a decorator.
-
-    """
-    return new_plugins_from_config(
-        config=config, type=Type.WORKLOAD, label=label, base=base)
-
-
-def new_workload_from_config(config: Config,
-                             label: str = UCTT_WORKLOAD_CONFIG_LABEL,
-                             base: str = UCTT_WORKLOAD_CONFIG_KEY_WORKLOAD) -> WorkloadBase:
-    """ Create a workload from some config
-
-    This method will interpret some config values as being usable to build
-    workload
-
-    Parameters:
-    -----------
-
-    config (Config) : Used to load and get the workload configuration
-
-    label (str) : config label to load to pull workload configuration. That
-        label is loaded and config is pulled to produce a list of workloads
-
-    base (str) : config key to get a Dict of workloads configurations.
-
-    Returns:
-    --------
-
-    workload plugin (WorkloadBase)
-
-    Raises:
-    -------
-
-    If you ask for a plugin which has not been registered, then you're going to
-    get a NotImplementedError exception.
-    To make sure that your desired plugin is registered, make sure to import
-    the module that contains the factory method with a decorator.
-
-    """
-    return new_plugin_from_config(
-        config=config, type=Type.WORKLOAD, label=label, base=base)
-
-
-def new_workloads_from_dict(
-        config: Config, workload_list: Dict[str, Dict]) -> PluginInstances:
-    """ Create a set of workload plugins from Dict information
-
-    The passed dict should be a key=>details map of workloads, which will be turned
-    into a PluginInstances map of plugins that can be used to interact with the
-    objects.
-
-    Parameters:
-    -----------
-
-    config (Config) : configerus.Config object passed to each generated plugins.
-
-    workload_list (Dict[str, Dict]) : map of key=> config dicts, where each dict
-        contains all of the information that is needed to build the plugin.
-
-        for details, @see new_plugins_from_dict
-
-    Returns:
-    --------
-
-    A PluginsInstances object with the plugin objects created
-
-    """
-    return new_plugins_from_dict(
-        config=config, type=Type.WORKLOAD, plugin_list=workload_list)
-
-
-def new_workload_from_dict(
-        config: Config, workload_dict: Dict[str, Any]) -> WorkloadBase:
-    """ Create a single workload plugin from a Dict of information for it
-
-    Create a new workload plugin from a map/dict of settings for the needed parameters.
-
-    Parameters:
-    -----------
-
-    config (Config) : configerus.Config object passed to each generated plugins.
-
-    workload_dict (Dict[str,Any]) : Dict from which all needed information will
-        be pulled.  Optionally additional config sources can be included as well
-        as arguments which could be passed to the plugin.
-
-        @see new_plugin_from_dict for more details.
-
-    Return:
-    -------
-
-    A plugin object (WorkloadBase)
-
-    """
-    return new_plugin_from_dict(
-        config=config, type=Type.WORKLOAD, plugin_dict=workload_dict)
-
-
-def new_workload(config: Config, plugin_id: str,
-                 instance_id: str) -> WorkloadBase:
-    """ Create a new workload from parameters
-
-    Parameters:
-    -----------
-
-    config (Config) : configerus.Config object passed to each generated plugins.
-
-    plugin_id (str) : UCTT plugin id for the workload type, to tell us what plugin
-        factory to load.
-
-        @see .plugin.Factory for more details on how plugins are loaded.
-
-    instance_id (str) : string instance id that will be passed to the new plugin
-        object.
-
-    Return:
-    -------
-
-    A plugin object (WorkloadBase)
-
-    """
-    return new_plugin(config=config, type=Type.WORKLOAD,
-                      plugin_id=plugin_id, instance_id=instance_id)
-
-
 """ OUTPUT CONSTRUCTION """
-
-UCTT_OUTPUTS_CONFIG_LABEL = 'outputs'
-""" outputs_from_config will load this config to decide how to build output plugins """
-UCTT_OUTPUTS_CONFIG_KEY_OUTPUTS = '.'
-""" default loaded config get key for outputs in UCTT_OUTPUTS_CONFIG_LABEL """
-UCTT_OUTPUT_CONFIG_LABEL = 'output'
-""" default config label which should define a single output """
-UCTT_OUTPUT_CONFIG_KEY_OUTPUT = '.'
-""" default loaded config get key for output settings in UCTT_OUTPUT_CONFIG_LABEL """
 
 
 def new_outputs_from_config(config: Config,
-                            label: str = UCTT_OUTPUTS_CONFIG_LABEL,
-                            base: str = UCTT_OUTPUTS_CONFIG_KEY_OUTPUTS) -> PluginInstances:
+                            label: str = UCTT_OUTPUT_CONFIG_OUTPUTS_LABEL,
+                            base: Any = LOADED_KEY_ROOT) -> PluginInstances:
     """ Create outputs from some config
 
     This method will interpret some config values as being usable to build
@@ -792,7 +462,11 @@ def new_outputs_from_config(config: Config,
     label (str) : config label to load to pull output configuration. That
         label is loaded and config is pulled to produce a list of outputs
 
-    base (str) : config key to get a Dict of output configurations.
+    base (str|List) : config key to get a Dict of plugins configurations.
+        A list of strings is valid as configerus.loaded.get() can take that as
+        an argument.
+        We call this base instead of key as we will be searching for sub-paths
+        to pull individual elements
 
     Returns:
     --------
@@ -813,8 +487,8 @@ def new_outputs_from_config(config: Config,
 
 
 def new_output_from_config(config: Config,
-                           label: str = UCTT_OUTPUT_CONFIG_LABEL,
-                           base: str = UCTT_OUTPUT_CONFIG_KEY_OUTPUT) -> OutputBase:
+                           label: str = UCTT_OUTPUT_CONFIG_OUTPUT_LABEL,
+                           base: Any = LOADED_KEY_ROOT) -> OutputBase:
     """ Create a output from some config
 
     This method will interpret some config values as being usable to build
@@ -828,7 +502,11 @@ def new_output_from_config(config: Config,
     label (str) : config label to load to pull output configuration. That
         label is loaded and config is pulled to produce a list of outputs
 
-    base (str) : config key to get a Dict of output configurations.
+    base (str|List) : config key to get a Dict of plugins configurations.
+        A list of strings is valid as configerus.loaded.get() can take that as
+        an argument.
+        We call this base instead of key as we will be searching for sub-paths
+        to pull individual elements
 
     Returns:
     --------
@@ -927,4 +605,169 @@ def new_output(config: Config, plugin_id: str,
 
     """
     return new_plugin(config=config, type=Type.OUTPUT,
+                      plugin_id=plugin_id, instance_id=instance_id)
+
+
+""" WORKLOAD CONSTRUCTION """
+
+
+def new_workloads_from_config(config: Config,
+                              label: str = UCTT_WORKLOAD_CONFIG_WORKLOADS_LABEL,
+                              base: Any = LOADED_KEY_ROOT) -> PluginInstances:
+    """ Create workloads from some config
+
+    This method will interpret some config values as being usable to build
+    a PluginInstances set of workload plugins
+
+    Parameters:
+    -----------
+
+    config (Config) : Used to load and get the workload configuration
+
+    label (str) : config label to load to pull workload configuration. That
+        label is loaded and config is pulled to produce a list of workloads
+
+    base (str|List) : config key to get a Dict of plugins configurations.
+        A list of strings is valid as configerus.loaded.get() can take that as
+        an argument.
+        We call this base instead of key as we will be searching for sub-paths
+        to pull individual elements
+
+    Returns:
+    --------
+
+    PluginInstances of workload plugins
+
+    Raises:
+    -------
+
+    If you ask for a plugin which has not been registered, then you're going to
+    get a NotImplementedError exception.
+    To make sure that your desired plugin is registered, make sure to import
+    the module that contains the factory method with a decorator.
+
+    """
+    return new_plugins_from_config(
+        config=config, type=Type.WORKLOAD, label=label, base=base)
+
+
+def new_workload_from_config(config: Config,
+                             label: str = UCTT_WORKLOAD_CONFIG_WORKLOAD_LABEL,
+                             base: Any = LOADED_KEY_ROOT) -> WorkloadBase:
+    """ Create a workload from some config
+
+    This method will interpret some config values as being usable to build
+    workload
+
+    Parameters:
+    -----------
+
+    config (Config) : Used to load and get the workload configuration
+
+    label (str) : config label to load to pull workload configuration. That
+        label is loaded and config is pulled to produce a list of workloads
+
+    base (str|List) : config key to get a Dict of plugin configuration.
+        A list of strings is valid as configerus.loaded.get() can take that as
+        an argument.
+        We call this base instead of key as we will be searching for sub-paths
+        to pull individual elements
+
+    Returns:
+    --------
+
+    workload plugin (WorkloadBase)
+
+    Raises:
+    -------
+
+    If you ask for a plugin which has not been registered, then you're going to
+    get a NotImplementedError exception.
+    To make sure that your desired plugin is registered, make sure to import
+    the module that contains the factory method with a decorator.
+
+    """
+    return new_plugin_from_config(
+        config=config, type=Type.WORKLOAD, label=label, base=base)
+
+
+def new_workloads_from_dict(
+        config: Config, workload_list: Dict[str, Dict]) -> PluginInstances:
+    """ Create a set of workload plugins from Dict information
+
+    The passed dict should be a key=>details map of workloads, which will be turned
+    into a PluginInstances map of plugins that can be used to interact with the
+    objects.
+
+    Parameters:
+    -----------
+
+    config (Config) : configerus.Config object passed to each generated plugins.
+
+    workload_list (Dict[str, Dict]) : map of key=> config dicts, where each dict
+        contains all of the information that is needed to build the plugin.
+
+        for details, @see new_plugins_from_dict
+
+    Returns:
+    --------
+
+    A PluginsInstances object with the plugin objects created
+
+    """
+    return new_plugins_from_dict(
+        config=config, type=Type.WORKLOAD, plugin_list=workload_list)
+
+
+def new_workload_from_dict(
+        config: Config, workload_dict: Dict[str, Any]) -> WorkloadBase:
+    """ Create a single workload plugin from a Dict of information for it
+
+    Create a new workload plugin from a map/dict of settings for the needed parameters.
+
+    Parameters:
+    -----------
+
+    config (Config) : configerus.Config object passed to each generated plugins.
+
+    workload_dict (Dict[str,Any]) : Dict from which all needed information will
+        be pulled.  Optionally additional config sources can be included as well
+        as arguments which could be passed to the plugin.
+
+        @see new_plugin_from_dict for more details.
+
+    Return:
+    -------
+
+    A plugin object (WorkloadBase)
+
+    """
+    return new_plugin_from_dict(
+        config=config, type=Type.WORKLOAD, plugin_dict=workload_dict)
+
+
+def new_workload(config: Config, plugin_id: str,
+                 instance_id: str) -> WorkloadBase:
+    """ Create a new workload from parameters
+
+    Parameters:
+    -----------
+
+    config (Config) : configerus.Config object passed to each generated plugins.
+
+    plugin_id (str) : UCTT plugin id for the workload type, to tell us what plugin
+        factory to load.
+
+        @see .plugin.Factory for more details on how plugins are loaded.
+
+    instance_id (str) : string instance id that will be passed to the new plugin
+        object.
+
+    Return:
+    -------
+
+    A plugin object (WorkloadBase)
+
+    """
+    return new_plugin(config=config, type=Type.WORKLOAD,
                       plugin_id=plugin_id, instance_id=instance_id)

--- a/uctt/__init__.py
+++ b/uctt/__init__.py
@@ -1,8 +1,22 @@
+"""
+
+UCTT Core toolset
+
+In this module, the root package, are found a number of tool plugin constructors
+that can be used to get instances of the plugins based on either passed in data
+or configerus config.
+
+The contstruction.py module does the heavy lifting of building plugins and
+PluginInstances sets.
+
+"""
+
 from importlib import metadata
 from typing import Dict, List, Any
 import logging
 
 from configerus.config import Config
+from configerus.loaded import LOADED_KEY_ROOT
 from configerus.contrib.dict import PLUGIN_ID_SOURCE_DICT
 
 from .plugin import Type
@@ -84,7 +98,7 @@ def bootstrap(config: Config, bootstraps=[]):
 
 UCTT_PROVISIONERS_CONFIG_LABEL = 'provisioners'
 """ provisioners_from_config will load this config to decide how to build provisioner plugins """
-UCTT_PROVISIONERS_CONFIG_KEY_PROVISIONERS = '.'
+UCTT_PROVISIONERS_CONFIG_KEY_PROVISIONERS = LOADED_KEY_ROOT
 """ default loaded config get key for provisioners in UCTT_PROVISIONERS_CONFIG_LABEL """
 UCTT_PROVISIONER_CONFIG_LABEL = 'provisioner'
 """ default config label which should define a single provisioner """
@@ -94,11 +108,13 @@ UCTT_PROVISIONER_CONFIG_KEY_PROVISIONER = '.'
 
 def new_provisioners_from_config(config: Config,
                                  label: str = UCTT_PROVISIONERS_CONFIG_LABEL,
-                                 key: str = UCTT_PROVISIONERS_CONFIG_KEY_PROVISIONERS) -> PluginInstances:
+                                 base: str = UCTT_PROVISIONERS_CONFIG_KEY_PROVISIONERS) -> PluginInstances:
     """ Create provisioners from some config
 
     This method will interpret some config values as being usable to build
     a PluginInstances set of provisioner plugins
+
+    @TODO - we should enable configerus validation
 
     Parameters:
     -----------
@@ -108,7 +124,7 @@ def new_provisioners_from_config(config: Config,
     label (str) : config label to load to pull provisioner configuration. That
         label is loaded and config is pulled to produce a list of provisioners
 
-    key (str) : config key to get a Dict of provisioners configurations.
+    base (str) : config key to get a Dict of provisioners configurations.
 
     Returns:
     --------
@@ -125,12 +141,11 @@ def new_provisioners_from_config(config: Config,
 
     """
     return new_plugins_from_config(
-        config=config, type=Type.PROVISIONER, label=label, key=key)
+        config=config, type=Type.PROVISIONER, label=label, base=base)
 
 
-def new_provisioner_from_config(config: Config,
-                                label: str = UCTT_PROVISIONER_CONFIG_LABEL,
-                                key: str = UCTT_PROVISIONER_CONFIG_KEY_PROVISIONER) -> ProvisionerBase:
+def new_provisioner_from_config(config: Config, label: str = UCTT_PROVISIONER_CONFIG_LABEL,
+                                base: str = UCTT_PROVISIONER_CONFIG_KEY_PROVISIONER, instance_id: str = '') -> ProvisionerBase:
     """ Create a provisioner from some config
 
     This method will interpret some config values as being usable to build a
@@ -144,7 +159,9 @@ def new_provisioner_from_config(config: Config,
     label (str) : config label to load to pull provisioner configuration. That
         label is loaded and config is pulled to produce a list of provisioners
 
-    key (str) : config key to get a Dict of provisioners configurations.
+    base (str) : config key to get a Dict of provisioners configurations.
+
+    instance_id (str) : optionally force a particular instance_id to be assigned
 
     Returns:
     --------
@@ -160,10 +177,10 @@ def new_provisioner_from_config(config: Config,
     the module that contains the factory method with a decorator.
 
     """
-    logger.debug("Creating provisioner: [{}]:[{}][{}] : {}".format(
-        label, key, instance_id, config.load(label).get(key)))
+    logger.debug("Creating provisioner: [{}]:[{}][{}]".format(
+        label, base, instance_id))
     return new_plugin_from_config(
-        config=config, type=Type.PROVISIONER, label=label, key=key)
+        config=config, type=Type.PROVISIONER, label=label, base=base)
 
 
 def new_provisioners_from_dict(
@@ -195,7 +212,7 @@ def new_provisioners_from_dict(
 
 
 def new_provisioner_from_dict(
-        config: Config, provisioner_dict: Dict[str, Any]) -> ProvisionerBase:
+        config: Config, provisioner_dict: Dict[str, Any], instance_id: str = '') -> ProvisionerBase:
     """ Create a provisioner plugin from a Dict of information for it
 
     Create a new provisioner plugin from a map/dict of settings for the needed parameters.
@@ -211,6 +228,8 @@ def new_provisioner_from_dict(
 
         @see new_plugin_from_dict for more details.
 
+    instance_id (str) : optionally force a particular instance_id to be assigned
+
     Return:
     -------
 
@@ -218,7 +237,7 @@ def new_provisioner_from_dict(
 
     """
     return new_plugin_from_dict(
-        config=config, type=Type.PROVISIONER, plugin_dict=provisioner_dict)
+        config=config, type=Type.PROVISIONER, plugin_dict=provisioner_dict, instance_id=instance_id)
 
 
 def new_provisioner(config: Config, plugin_id: str,
@@ -262,7 +281,7 @@ UCTT_CLIENT_CONFIG_KEY_CLIENT = '.'
 
 def new_clients_from_config(config: Config,
                             label: str = UCTT_CLIENTS_CONFIG_LABEL,
-                            key: str = UCTT_CLIENTS_CONFIG_KEY_CLIENTS) -> PluginInstances:
+                            base: str = UCTT_CLIENTS_CONFIG_KEY_CLIENTS) -> PluginInstances:
     """ Create clients from some config
 
     This method will interpret some config values as being usable to build
@@ -276,7 +295,7 @@ def new_clients_from_config(config: Config,
     label (str) : config label to load to pull client configuration. That
         label is loaded and config is pulled to produce a list of clients
 
-    key (str) : config key to get a Dict of clients configurations.
+    base (str) : config key to get a Dict of clients configurations.
 
     Returns:
     --------
@@ -293,12 +312,12 @@ def new_clients_from_config(config: Config,
 
     """
     return new_plugins_from_config(
-        config=config, type=Type.CLIENT, label=label, key=key)
+        config=config, type=Type.CLIENT, label=label, base=base)
 
 
 def new_client_from_config(config: Config,
                            label: str = UCTT_CLIENT_CONFIG_LABEL,
-                           key: str = UCTT_CLIENT_CONFIG_KEY_CLIENT) -> ClientBase:
+                           base: str = UCTT_CLIENT_CONFIG_KEY_CLIENT) -> ClientBase:
     """ Create a client from some config
 
     This method will interpret some config values as being usable to build a
@@ -312,7 +331,7 @@ def new_client_from_config(config: Config,
     label (str) : config label to load to pull client configuration. That
         label is loaded and config is pulled to produce a list of clients
 
-    key (str) : config key to get a Dict of clients configurations.
+    base (str) : config key to get a Dict of clients configurations.
 
     Returns:
     --------
@@ -329,7 +348,7 @@ def new_client_from_config(config: Config,
 
     """
     return new_plugin_from_config(
-        config=config, type=Type.CLIENT, label=label, key=key)
+        config=config, type=Type.CLIENT, label=label, base=base)
 
 
 def new_clients_from_dict(
@@ -427,7 +446,7 @@ UCTT_WORKLOAD_CONFIG_KEY_WORKLOAD = '.'
 
 def new_workloads_from_config(config: Config,
                               label: str = UCTT_WORKLOADS_CONFIG_LABEL,
-                              key: str = UCTT_WORKLOADS_CONFIG_KEY_WORKLOADS) -> PluginInstances:
+                              base: str = UCTT_WORKLOADS_CONFIG_KEY_WORKLOADS) -> PluginInstances:
     """ Create workloads from some config
 
     This method will interpret some config values as being usable to build
@@ -441,7 +460,7 @@ def new_workloads_from_config(config: Config,
     label (str) : config label to load to pull workload configuration. That
         label is loaded and config is pulled to produce a list of workloads
 
-    key (str) : config key to get a Dict of workloads configurations.
+    base (str) : config key to get a Dict of workloads configurations.
 
     Returns:
     --------
@@ -458,12 +477,12 @@ def new_workloads_from_config(config: Config,
 
     """
     return new_plugins_from_config(
-        config=config, type=Type.WORKLOAD, label=label, key=key)
+        config=config, type=Type.WORKLOAD, label=label, base=base)
 
 
 def new_workload_from_config(config: Config,
                              label: str = UCTT_WORKLOAD_CONFIG_LABEL,
-                             key: str = UCTT_WORKLOAD_CONFIG_KEY_WORKLOAD) -> WorkloadBase:
+                             base: str = UCTT_WORKLOAD_CONFIG_KEY_WORKLOAD) -> WorkloadBase:
     """ Create a workload from some config
 
     This method will interpret some config values as being usable to build
@@ -477,7 +496,7 @@ def new_workload_from_config(config: Config,
     label (str) : config label to load to pull workload configuration. That
         label is loaded and config is pulled to produce a list of workloads
 
-    key (str) : config key to get a Dict of workloads configurations.
+    base (str) : config key to get a Dict of workloads configurations.
 
     Returns:
     --------
@@ -494,7 +513,7 @@ def new_workload_from_config(config: Config,
 
     """
     return new_plugin_from_config(
-        config=config, type=Type.WORKLOAD, label=label, key=key)
+        config=config, type=Type.WORKLOAD, label=label, base=base)
 
 
 def new_workloads_from_dict(
@@ -593,7 +612,7 @@ UCTT_WORKLOAD_CONFIG_KEY_WORKLOAD = '.'
 
 def new_workloads_from_config(config: Config,
                               label: str = UCTT_WORKLOADS_CONFIG_LABEL,
-                              key: str = UCTT_WORKLOADS_CONFIG_KEY_WORKLOADS) -> PluginInstances:
+                              base: str = UCTT_WORKLOADS_CONFIG_KEY_WORKLOADS) -> PluginInstances:
     """ Create workloads from some config
 
     This method will interpret some config values as being usable to build
@@ -607,7 +626,7 @@ def new_workloads_from_config(config: Config,
     label (str) : config label to load to pull workload configuration. That
         label is loaded and config is pulled to produce a list of workloads
 
-    key (str) : config key to get a Dict of workloads configurations.
+    base (str) : config key to get a Dict of workloads configurations.
 
     Returns:
     --------
@@ -624,12 +643,12 @@ def new_workloads_from_config(config: Config,
 
     """
     return new_plugins_from_config(
-        config=config, type=Type.WORKLOAD, label=label, key=key)
+        config=config, type=Type.WORKLOAD, label=label, base=base)
 
 
 def new_workload_from_config(config: Config,
                              label: str = UCTT_WORKLOAD_CONFIG_LABEL,
-                             key: str = UCTT_WORKLOAD_CONFIG_KEY_WORKLOAD) -> WorkloadBase:
+                             base: str = UCTT_WORKLOAD_CONFIG_KEY_WORKLOAD) -> WorkloadBase:
     """ Create a workload from some config
 
     This method will interpret some config values as being usable to build
@@ -643,7 +662,7 @@ def new_workload_from_config(config: Config,
     label (str) : config label to load to pull workload configuration. That
         label is loaded and config is pulled to produce a list of workloads
 
-    key (str) : config key to get a Dict of workloads configurations.
+    base (str) : config key to get a Dict of workloads configurations.
 
     Returns:
     --------
@@ -660,7 +679,7 @@ def new_workload_from_config(config: Config,
 
     """
     return new_plugin_from_config(
-        config=config, type=Type.WORKLOAD, label=label, key=key)
+        config=config, type=Type.WORKLOAD, label=label, base=base)
 
 
 def new_workloads_from_dict(
@@ -759,7 +778,7 @@ UCTT_OUTPUT_CONFIG_KEY_OUTPUT = '.'
 
 def new_outputs_from_config(config: Config,
                             label: str = UCTT_OUTPUTS_CONFIG_LABEL,
-                            key: str = UCTT_OUTPUTS_CONFIG_KEY_OUTPUTS) -> PluginInstances:
+                            base: str = UCTT_OUTPUTS_CONFIG_KEY_OUTPUTS) -> PluginInstances:
     """ Create outputs from some config
 
     This method will interpret some config values as being usable to build
@@ -773,7 +792,7 @@ def new_outputs_from_config(config: Config,
     label (str) : config label to load to pull output configuration. That
         label is loaded and config is pulled to produce a list of outputs
 
-    key (str) : config key to get a Dict of outputs configurations.
+    base (str) : config key to get a Dict of output configurations.
 
     Returns:
     --------
@@ -790,12 +809,12 @@ def new_outputs_from_config(config: Config,
 
     """
     return new_plugins_from_config(
-        config=config, type=Type.OUTPUT, label=label, key=key)
+        config=config, type=Type.OUTPUT, label=label, base=base)
 
 
 def new_output_from_config(config: Config,
                            label: str = UCTT_OUTPUT_CONFIG_LABEL,
-                           key: str = UCTT_OUTPUT_CONFIG_KEY_OUTPUT) -> OutputBase:
+                           base: str = UCTT_OUTPUT_CONFIG_KEY_OUTPUT) -> OutputBase:
     """ Create a output from some config
 
     This method will interpret some config values as being usable to build
@@ -809,7 +828,7 @@ def new_output_from_config(config: Config,
     label (str) : config label to load to pull output configuration. That
         label is loaded and config is pulled to produce a list of outputs
 
-    key (str) : config key to get a Dict of outputs configurations.
+    base (str) : config key to get a Dict of output configurations.
 
     Returns:
     --------
@@ -826,7 +845,7 @@ def new_output_from_config(config: Config,
 
     """
     return new_plugin_from_config(
-        config=config, type=Type.OUTPUT, label=label, key=key)
+        config=config, type=Type.OUTPUT, label=label, base=base)
 
 
 def new_outputs_from_dict(

--- a/uctt/client.py
+++ b/uctt/client.py
@@ -9,11 +9,13 @@ logger = logging.getLogger('uctt.client')
 UCTT_PLUGIN_TYPE_CLIENT = Type.CLIENT
 """ Fast access to the client plugin_id """
 
-UCTT_OUTPUT_CONFIG_CLIENTS_LABEL = 'clients'
+UCTT_CLIENT_CONFIG_CLIENTS_LABEL = 'clients'
 """ A centralized configerus label for multiple clients """
-UCTT_OUTPUT_CONFIG_CLIENTS_KEY = 'clients'
+UCTT_CLIENT_CONFIG_CLIENT_LABEL = 'client'
+""" A centralized configerus label for a client """
+UCTT_CLIENT_CONFIG_CLIENTS_KEY = 'clients'
 """ A centralized configerus key for multiple clients """
-UCTT_OUTPUT_CONFIG_CLIENT_KEY = 'client'
+UCTT_CLIENT_CONFIG_CLIENT_KEY = 'client'
 """ A centralized configerus key for one client """
 
 

--- a/uctt/client.py
+++ b/uctt/client.py
@@ -2,18 +2,21 @@ import logging
 
 from configerus.config import Config
 
-from .plugin import UCTTPlugin, Type
+from .plugin import UCCTArgumentsPlugin, Type
 
 logger = logging.getLogger('uctt.client')
 
-UCTT_PLUGIN_ID_CLIENT = Type.CLIENT
+UCTT_PLUGIN_TYPE_CLIENT = Type.CLIENT
 """ Fast access to the client plugin_id """
 
+UCTT_OUTPUT_CONFIG_CLIENTS_LABEL = 'clients'
+""" A centralized configerus label for multiple clients """
+UCTT_OUTPUT_CONFIG_CLIENTS_KEY = 'clients'
+""" A centralized configerus key for multiple clients """
+UCTT_OUTPUT_CONFIG_CLIENT_KEY = 'client'
+""" A centralized configerus key for one client """
 
-class ClientBase(UCTTPlugin):
+
+class ClientBase(UCCTArgumentsPlugin):
     """ Base class for client plugins """
-
-    def arguments(**kwargs):
-        """ Receive a list of arguments for this client """
-        raise NotImplemented(
-            'arguments() was not implemented for this client plugin')
+    pass

--- a/uctt/constructors.py
+++ b/uctt/constructors.py
@@ -2,31 +2,66 @@
 
 Generic Plugin construction
 
+We have a whole module for general plugin creation because we want to keep the
+__init__.py as short as possible to focus on exports.
+
+Here we have methods that can create lists/sets of plugins as PluginInstances
+objects, or individual plugins.
+PluginInstances are used for sets of plugins in order to leverage the searching
+features.  Sorting is there but not heavily leveraged.
+
+The primary consumer of this code is the uctt package (__init__.py) where there
+are a number of plugin type specific factory methods for general consumption.
+
+Sets and individual plugins can be created from configerus config (preferred) or
+python nested dicts.  The dicts are actually just converted to configerus
+sources and passed to the config based methods.
+
+We used configerus configs:
+1. to gain deep searching when looking for config;
+2. to allow for configerus pattern formatting and validation;
+3. to standardize.
+
+The process for plugin creation is based on convention of layout of the config
+source.
+
+1. we always need a 'type' (UCTT_PLUGIN_CONFIG_KEY_TYPE) to know what type of
+    plugin to create.  You can create mixed lists by relying on config to
+    describe what type to create;
+2. we always want a `plugin_id` (UCTT_PLUGIN_CONFIG_KEY_PLUGINID) to know what
+    plugin to create;
+3. every plugin needs an `instance_id` (UCTT_PLUGIN_CONFIG_KEY_INSTANCEID if
+    you want to be able to retrieve it by name. This can be pulled from the list
+    keys, or config, but the individual plugin methods allow it to be specified;
+4. plugin `priority` can be specified if you want to add multiple similar plugins
+    but prefer one over another on generic retrieval;
+5. if creating individual plugins, you can include additional `config` which
+    will be made available to the plugin as an additional config source (dict);
+6 it is possible to include a configerus validator key which will be applied to
+    the config for each plugin before it is created.
+
 """
 import logging
 from typing import List, Dict, Any
 
 from configerus.config import Config
 from configerus.loaded import LOADED_KEY_ROOT
+from configerus.contrib.dict import PLUGIN_ID_SOURCE_DICT
 
-from .plugin import Factory, Type, UCTTPlugin
+from .plugin import (Factory, Type, UCTTPlugin, UCTT_PLUGIN_CONFIG_KEY_TYPE,
+                     UCTT_PLUGIN_CONFIG_KEY_PLUGINID, UCTT_PLUGIN_CONFIG_KEY_INSTANCEID,
+                     UCTT_PLUGIN_CONFIG_KEY_ARGUMENTS, UCTT_PLUGIN_CONFIG_KEY_PRIORITY, UCTT_PLUGIN_CONFIG_KEY_CONFIG,
+                     UCTT_PLUGIN_CONFIG_KEY_VALIDATORS)
+                     # a lot of centralized config labels and keys are kept in .plugin
 from .instances import PluginInstances
 
+
+""" configerus .get() key for plugin type """
 logger = logging.getLogger('uctt.construction')
 
 
-UCTT_PLUGIN_CONFIG_KEY_PLUGINID = 'plugin_id'
-""" plugins_from_config will use this Dict key from the plugin config to decide what plugin to create """
-UCTT_PLUGIN_CONFIG_KEY_INSTANCEID = 'instance_id'
-""" plugins_from_config will use this Dict key assign an instance_id """
-UCTT_PLUGIN_CONFIG_KEY_CONFIG = 'config'
-""" new_plugins_from_config will use this Dict key as additional config """
-UCTT_PLUGIN_CONFIG_KEY_ARGS = 'arguments'
-""" new_plugins_from_config will use this Dict key from the plugin config to decide what arguments to pass to the plugin """
-
-
-def new_plugins_from_config(
-        config: Config, type: Type, label: str, key: str) -> PluginInstances:
+def new_plugins_from_config(config: Config, label: str, base: Any = LOADED_KEY_ROOT, type: Type = '', validator: str = '',
+                            exception_if_missing: bool = False) -> PluginInstances:
     """ Create plugins from some config
 
     This method will interpret some config values as being usable to build a Dict
@@ -40,7 +75,14 @@ def new_plugins_from_config(
     label (str) : config label to load to pull plugin configuration. That
         label is loaded and config is pulled to produce a list of plugins
 
-    key (str) : config key to get a Dict of plugins configurations.
+    base (str) : config key to get a Dict of plugins configurations.  This should
+        point to a dict of plugin configurations.
+
+    type (.plugin.Type) : plugin type to create, pulled from the config/dict if
+        omitted
+
+    validator (str) : optionally use a configerus validator on the instance
+        config/dict before a plugin is created.
 
     Returns:
     --------
@@ -56,20 +98,44 @@ def new_plugins_from_config(
     the module that contains the factory method with a decorator.
 
     """
+    # sometime we get an empty string instead of the root value
+    if not base:
+        logger.warn(
+            'Received an empty config .get(base=) value.  Assuming it was meant to be LOADED_KEY_ROOT')
+        base = LOADED_KEY_ROOT
+
+    instances = PluginInstances(config=config)
+    """ plugin set which will be used to create new plugins """
 
     try:
         plugin_config = config.load(label)
-        plugin_list = plugin_config.get(key, exception_if_missing=True)
+        plugin_list = plugin_config.get(base, exception_if_missing=True)
     except KeyError as e:
-        # there is not config so we can ignore this
-        return {}
+        if exception_if_missing:
+            return KeyError('Could not load any config for plugin generation')
+            # there is not config so we can ignore this
+        else:
+            return instances
 
-    return new_plugins_from_dict(
-        config=config, type=type, plugin_list=plugin_list)
+    for instance_id in plugin_list.keys():
+        # a new base will extend the given key for this list, if it is not root
+        instance_base = '{}.{}'.format(
+            base, instance_id) if not base == LOADED_KEY_ROOT else instance_id
+
+        new_plugin_from_config(
+            config=config,
+            label=label,
+            base=instance_base,
+            type=type,
+            instance_id=instance_id,
+            validator=validator,
+            instances=instances)
+
+    return instances
 
 
-def new_plugins_from_dict(config: Config, type: Type,
-                          plugin_list: Dict[str, Dict[str, Any]]) -> PluginInstances:
+def new_plugins_from_dict(config: Config, plugin_list: Dict[str, Dict[str, Any]], type: Type = '',
+                          validator: str = '') -> PluginInstances:
     """ Create a set of plugins from Dict information
 
     The passed dict should be a key=>details map of plugins, which will be turned
@@ -81,12 +147,16 @@ def new_plugins_from_dict(config: Config, type: Type,
 
     config (Config) : configerus.Config object passed to each generated plugins.
 
-    type (.plugin.Type) : plugin type to create
+    type (.plugin.Type) : plugin type to create, pulled from the config/dict if
+        omitted
 
     provisioner_list (Dict[str, Dict]) : map of key=> config dicts, where each dict
         contains all of the information that is needed to build the plugin.
 
         for details, @see new_plugin_from_dict
+
+    validator (str) : optionally use a configerus validator on the instance
+        config/dict before a plugin is created.
 
     Returns:
     --------
@@ -94,63 +164,27 @@ def new_plugins_from_dict(config: Config, type: Type,
     A PluginsInstances object with the plugin objects created
 
     """
-    plugins = PluginInstances(config=config)
+    instances = PluginInstances(config=config)
 
     if not isinstance(plugin_list, dict):
         raise ValueError(
             'Did not receive a good dict of config to make plugins from: %s',
             plugin_list)
 
-    for instance_id, plugin_config in plugin_list.items():
-        if not isinstance(plugin_config, dict):
-            raise ValueError(
-                "Recevied bad plugin configuration, expected Dict[str,Any], got '{}'".format(plugin_config))
+    for instance_id, plugin_dict in plugin_list.items():
+        new_plugin_from_dict(
+            config=config,
+            plugin_dict=plugin_dict,
+            type=type,
+            instance_id=instance_id,
+            validator=validator,
+            instances=instances)
 
-        if not UCTT_PLUGIN_CONFIG_KEY_PLUGINID in plugin_config:
-            raise ValueError(
-                "Plugin dict was missing plugin_id : {}".format(plugin_config))
-        plugin_id = plugin_config[UCTT_PLUGIN_CONFIG_KEY_PLUGINID]
-
-        instance_config = config
-        # If we were given plugin config, then create a copy of the config
-        # object and add the passed config as new sources to the copy
-        if UCTT_PLUGIN_CONFIG_KEY_CONFIG in plugin_config:
-            instance_config = config.copy()
-            instance_config.add_source(
-                PLUGIN_ID_SOURCE_DICT,
-                'plugin-{}'.format(plugin_id)).set_data(
-                plugin_config[UCTT_PLUGIN_CONFIG_KEY_CONFIG])
-
-        # tell the instancelist to build a new plugin
-        plugin = plugins.add_plugin(
-            type, plugin_id, instance_id, 60)
-        if not plugin:
-            raise Exception("Did not create a good plugin")
-
-        if UCTT_PLUGIN_CONFIG_KEY_ARGS in plugin_config:
-            try:
-                arguments = plugin_config[UCTT_PLUGIN_CONFIG_KEY_ARGS]
-                plugin.arguments(**arguments)
-            except KeyError as e:
-                raise Exception(
-                    "Plugin [{}] did not like the arguments given: {}".format(
-                        plugin, e)) from e
-
-    return plugins
+    return instances
 
 
-UCTT_PLUGIN_CONFIG_KEY_PLUGINID = 'plugin_id'
-""" outputs_from_config will use this Dict key from the output config to decide what plugin to create """
-UCTT_PLUGIN_CONFIG_KEY_INSTANCEID = 'instance_id'
-""" outputs_from_config will use this Dict key assign an instance_id """
-UCTT_PLUGIN_CONFIG_KEY_CONFIG = 'config'
-""" new_outputs_from_config will use this Dict key as additional config """
-UCTT_PLUGIN_CONFIG_KEY_ARGS = 'arguments'
-""" new_outputs_from_config will use this Dict key from the output config to decide what arguments to pass to the plugin """
-
-
-def new_plugin_from_config(config: Config, type: Type,
-                           label: str, key: str, instance_id: str = '') -> UCTTPlugin:
+def new_plugin_from_config(config: Config, label: str, base: str = LOADED_KEY_ROOT, type: Type = None,
+                           instance_id: str = '', validator: str = '', instances: PluginInstances = None) -> UCTTPlugin:
     """ Create a plugin from some config
 
     This method will interpret some config values as being usable to build plugin
@@ -158,19 +192,38 @@ def new_plugin_from_config(config: Config, type: Type,
     Using a configerus config object allows us to leverage advanced configerus
     features such as tree searching, formatting and validation.
 
+    What is looked for:
+
+    1. valdiators if we need to validate the entire label/key before using it
+    2. type if we did not receive a type
+    3. plugin_id : which will tell us what plugin to load
+    4. optional instance_id if none was passed
+    5. config if you want config added - ONLY if instances is None
+       (plugins in PluginInstances cannot override config objects)
+    6. arguments that will be executed on an argument() method if the
+        plugin has it.
+
     Parameters:
     -----------
 
     config (Config) : Used to load and get the plugin configuration
 
-    type (.plugin.Type) : plugin type to create
+    type (.plugin.Type) : plugin type to create, pulled from the config/dict if
+        omitted
 
     label (str) : config label to load to pull plugin configuration. That
         label is loaded and config is pulled to produce a list of plugins
 
-    key (str) : config key to get a Dict of plugins configurations.
+    base (str) : config key used as a .get(base=) for all gets.  With this you
+        can instruct to pull config from a section of loaded config.
 
     instance_id (str) : optionally pass an instance_id for the item.
+
+    validator (str) : optionally use a configerus validator on the entire .get()
+        for the instance config.
+
+    instances (PluginInstances) : if provided, plugins are created by the object
+        and added to it, otherwise plugins are created directly
 
     Returns:
     --------
@@ -186,50 +239,102 @@ def new_plugin_from_config(config: Config, type: Type,
     the module that contains the factory method with a decorator.
 
     """
-    logger.debug('Create plugin [{}][{}] : {}'.format(
-        type, instance_id, config.load(label).get(key)))
+    logger.debug('Create plugin [{}][{}]'.format(type, instance_id))
+
+    # sometime we get an empty string instead of the root value
+    if not base:
+        logger.warn(
+            'Received an empty config .get(base=) value.  Assuming it was meant to be LOADED_KEY_ROOT')
+        base = LOADED_KEY_ROOT
 
     config_plugin = config.load(label)
     """ loaded configuration for the plugin """
 
-    plugin_id = config_plugin.get(UCTT_PLUGIN_CONFIG_KEY_PLUGINID)
+    validators = []
+    config_validators = config_plugin.get(
+        UCTT_PLUGIN_CONFIG_KEY_VALIDATORS, base=base)
+    if config_validators:
+        validators = config_validators
+    if validator:
+        validators.append(validator)
+    if len(validators):
+        for validator in validators:
+            config_plugin.get(base, validator=validator)
+
+    plugin_id = config_plugin.get(UCTT_PLUGIN_CONFIG_KEY_PLUGINID, base=base)
     if not plugin_id:
         raise ValueError(
             "Could not find a plugin_id when trying to create a plugin:[{}][{}][{}] : {}".format(type, label, key, config_plugin.get(key)))
 
+    if type is None:
+        type = config_plugin.get(UCTT_PLUGIN_CONFIG_KEY_TYPE, base=base)
+    if not type:
+        raise ValueError(
+            "Could not find a plugin type when trying to create a plugin:[{}][{}][{}] : {}".format(type, label, key, config_plugin.get(key)))
+
     # if no instance_id was passed, try to load one or just make one up
     if not instance_id:
-        instance_id = config_plugin.get(UCTT_PLUGIN_CONFIG_KEY_INSTANCEID)
-    if not instance_id:
-        instance_id = '{}-{}'.format(type, plugin_id)
+        instance_id = config_plugin.get(
+            UCTT_PLUGIN_CONFIG_KEY_INSTANCEID, base=base)
+        if not instance_id:
+            instance_id = '{}-{}'.format(type, plugin_id)
 
-    # If we were given a output config, then create a copy of the config
-    # object and add the passed config as new sources to the copy
-    plugin_dict = config_plugin.get(UCTT_PLUGIN_CONFIG_KEY_CONFIG)
-    if plugin_dict:
-        config = config.copy()
-        # Add a dict source plugin for the passed 'config', giving it source id
-        # just to make identification easier
-        instance_config.add_source(
-            PLUGIN_ID_SOURCE_DICT, '{}-{}-{}'.format(
-                type, plugin_id, instance_id)).set_data(
-            plugin_dict[UCTT_PLUGIN_CONFIG_KEY_CONFIG])
+    if instances is None:
+        # we are creating a plugin directly
 
-    plugin = new_plugin(
-        config=config,
-        type=type,
-        plugin_id=plugin_id,
-        instance_id=instance_id)
+        # If we were given a output config, then create a copy of the config
+        # object and add the passed config as new sources to the copy
+        plugin_config_dict = config_plugin.get(
+            UCTT_PLUGIN_CONFIG_KEY_CONFIG, base=base)
+        if plugin_config_dict:
+            config = config.copy()
+            # Add a dict source plugin for the passed 'config', giving it source id
+            # just to make identification easier
+            config_source_instance_id = 'plugin-{}-{}-{}'.format(
+                type, plugin_id, instance_id)
+            """ use this for aesthetics, as the new config source instance id """
+            config.add_source(
+                PLUGIN_ID_SOURCE_DICT,
+                config_source_instance_id).set_data(plugin_config_dict)
 
-    plugin_args = config_plugin.get(UCTT_PLUGIN_CONFIG_KEY_ARGS)
-    if plugin_args:
-        plugin.arguments(**plugin_args)
+        # Create the plugin directlu
+        plugin = new_plugin(
+            config=config,
+            type=type,
+            plugin_id=plugin_id,
+            instance_id=instance_id)
+    else:
+        # We are creating an instance, so we can look for a priority
+
+        priority = config_plugin.get(
+            UCTT_PLUGIN_CONFIG_KEY_INSTANCEID, base=base)
+        if not priority:
+            priority = config.default_priority()
+            """ instance priority - this is actually a stupid place to get it from """
+
+        # we can't pass config if creating the plugin as an instance in an instance list
+        # as that structure needs tight control over config for copying etc.
+        if config_plugin.get(UCTT_PLUGIN_CONFIG_KEY_CONFIG, base=base):
+            logger.warn(
+                'Creating a plugin for an instance list, but was given config overrides.  Ignoring it as this is not possible.')
+
+        plugin = instances.add_plugin(
+            type=type,
+            plugin_id=plugin_id,
+            instance_id=instance_id,
+            priority=priority)
+
+    if hasattr(plugin, 'arguments') and callable(getattr(plugin, 'arguments')):
+        plugin_args = config_plugin.get(
+            UCTT_PLUGIN_CONFIG_KEY_ARGUMENTS, base=base)
+        if plugin_args:
+            plugin.arguments(**plugin_args)
 
     return plugin
 
 
-def new_plugin_from_dict(config: Config, type: Type,
-                         plugin_dict: Dict[str, Any], instance_id: str = '') -> UCTTPlugin:
+def new_plugin_from_dict(config: Config, plugin_dict: Dict[str, Any], type: Type = None, instance_id: str = '',
+                         validator: str = '', instances: PluginInstances = None) -> UCTTPlugin:
     """ Create a single plugin from a Dict of information for it
 
     Create a new plugin from a map/dict of settings for the needed parameters.
@@ -248,7 +353,8 @@ def new_plugin_from_dict(config: Config, type: Type,
 
     config (Config) : configerus.Config object passed to each generated plugins.
 
-    type (.plugin.Type) : plugin type to create
+    type (.plugin.Type) : plugin type to create, pulled from the config/dict if
+        omitted
 
     client_dict (Dict[str,Any]) : Dict from which all needed information will
         be pulled.  Optionally additional config sources can be included as well
@@ -258,22 +364,28 @@ def new_plugin_from_dict(config: Config, type: Type,
 
     instance_id (str) : optionally pass an instance_id for the item.
 
+    validator (str) : optionally use a configerus validator on the entire .get()
+        for the instance config.
+
+    instances (PluginInstances) : if provided, plugins are created by the object
+        and added to it, otherwise plugins are created directly
+
     Return:
     -------
 
     A plugin object (UCTTPlugin)
 
     """
-    dict_id = '{}-{}-{}-plugin_dict'.format(type, plugin_id, instance_id)
+    plugin_config_source_id = '{}-{}-plugin_dict'.format(type, instance_id)
     """ unique identifier for this dict as a config label """
 
-    config = config.copy()
+    instance_config = config.copy()
     instance_config.add_source(
         PLUGIN_ID_SOURCE_DICT, ).set_data({
-            dict_id: plugin_dict
+            plugin_config_source_id: plugin_dict
         })
-    return new_plugin_from_config(
-        config, type, dict_id, LOADED_KEY_ROOT, instance_id)
+    return new_plugin_from_config(config=instance_config, type=type, label=plugin_config_source_id,
+            base=LOADED_KEY_ROOT, instance_id=instance_id, validator=validator, instances=instances)
 
 
 def new_plugin(config: Config, type: Type, plugin_id: str,

--- a/uctt/constructors.py
+++ b/uctt/constructors.py
@@ -68,7 +68,6 @@ def new_plugins_from_config(
         config=config, type=type, plugin_list=plugin_list)
 
 
-
 def new_plugins_from_dict(config: Config, type: Type,
                           plugin_list: Dict[str, Dict[str, Any]]) -> PluginInstances:
     """ Create a set of plugins from Dict information
@@ -187,12 +186,17 @@ def new_plugin_from_config(config: Config, type: Type,
     the module that contains the factory method with a decorator.
 
     """
+    logger.debug('Create plugin [{}][{}] : {}'.format(
+        type, instance_id, config.load(label).get(key)))
+
     config_plugin = config.load(label)
     """ loaded configuration for the plugin """
 
     plugin_id = config_plugin.get(UCTT_PLUGIN_CONFIG_KEY_PLUGINID)
     if not plugin_id:
-        raise ValueError('Could not find a plugin_id when trying to create a plugin')
+        raise ValueError(
+            "Could not find a plugin_id when trying to create a plugin:[{}][{}][{}] : {}".format(type, label, key, config_plugin.get(key)))
+
     # if no instance_id was passed, try to load one or just make one up
     if not instance_id:
         instance_id = config_plugin.get(UCTT_PLUGIN_CONFIG_KEY_INSTANCEID)
@@ -222,6 +226,7 @@ def new_plugin_from_config(config: Config, type: Type,
         plugin.arguments(**plugin_args)
 
     return plugin
+
 
 def new_plugin_from_dict(config: Config, type: Type,
                          plugin_dict: Dict[str, Any], instance_id: str = '') -> UCTTPlugin:
@@ -267,7 +272,8 @@ def new_plugin_from_dict(config: Config, type: Type,
         PLUGIN_ID_SOURCE_DICT, ).set_data({
             dict_id: plugin_dict
         })
-    return new_plugin_from_config(config, type, dict_id, LOADED_KEY_ROOT, instance_id)
+    return new_plugin_from_config(
+        config, type, dict_id, LOADED_KEY_ROOT, instance_id)
 
 
 def new_plugin(config: Config, type: Type, plugin_id: str,

--- a/uctt/contrib/common/dict_output.py
+++ b/uctt/contrib/common/dict_output.py
@@ -35,6 +35,8 @@ class DictOutputPlugin(OutputBase):
             applied to the data as it is added.
 
         """
+        assert isinstance(data, dict), type(data)
+
         self.config_instance_id = 'dict-output-{}'.format(self.instance_id)
         self.config.add_source(PLUGIN_ID_SOURCE_DICT, self.config_instance_id).set_data({
             self.config_instance_id: data

--- a/uctt/contrib/common/dict_output.py
+++ b/uctt/contrib/common/dict_output.py
@@ -1,7 +1,9 @@
-from uctt.output import OutputBase
-from configerus.contrib.dict import PLUGIN_ID_SOURCE_DICT
 import logging
 from typing import Dict
+
+from configerus.contrib.dict import PLUGIN_ID_SOURCE_DICT
+from configerus.loaded import LOADED_KEY_ROOT
+from uctt.output import OutputBase
 
 logger = logging.getLogger('uctt.contrib.common.output.dict')
 
@@ -14,7 +16,7 @@ class DictOutputPlugin(OutputBase):
 
     """
 
-    def arguments(self, data: Dict, validator: str = '.'):
+    def arguments(self, data: Dict, validator: str = ''):
         """ Assign data
 
         This turns the data into a dict configerus source and adds it to the
@@ -40,7 +42,7 @@ class DictOutputPlugin(OutputBase):
         self.loaded_config = self.config.load(
             self.config_instance_id, validator=validator)
 
-    def get_output(self, key: str = '', validator: str = ''):
+    def get_output(self, key: str = LOADED_KEY_ROOT, validator: str = ''):
         """ retrieve an output
 
         Because we treated that data as a high-priority configerus source with

--- a/uctt/contrib/common/text_output.py
+++ b/uctt/contrib/common/text_output.py
@@ -7,7 +7,7 @@ logger = logging.getLogger('uctt.contrib.common.output.text')
 class TextOutputPlugin(OutputBase):
     """ MTT Output plugin a text output type
 
-    this just gets and sets text
+    this just gets and sets text. Nothing fancy.
 
     """
 

--- a/uctt/contrib/docker/client.py
+++ b/uctt/contrib/docker/client.py
@@ -14,8 +14,8 @@ class DockerClientPlugin(ClientBase, DockerClient):
 
     """
 
-    def args(self, host: str, cert_path: str, tls_verify: bool = True,
-             compose_tls_version: str = 'TLSv1_2'):
+    def arguments(self, host: str, cert_path: str, tls_verify: bool = True,
+                  compose_tls_version: str = 'TLSv1_2'):
         """ Build the DockerClient
 
         In order to decorate this existing class as a DockerClient, without using the

--- a/uctt/contrib/dummy/provisioner.py
+++ b/uctt/contrib/dummy/provisioner.py
@@ -63,7 +63,7 @@ import uctt
 from uctt.provisioner import ProvisionerBase
 from uctt.plugin import Type
 from uctt.output import UCTT_OUTPUT_CONFIG_OUTPUTS_KEY
-from uctt.client import UCTT_OUTPUT_CONFIG_CLIENTS_KEY
+from uctt.client import UCTT_CLIENT_CONFIG_CLIENTS_KEY
 
 logger = logging.getLogger('uctt.contrib.dummy.provisioner')
 
@@ -71,7 +71,7 @@ UCTT_DUMMY_PROVISIONER_CONFIG_LABEL = 'provisioner'
 """ What config label should be loaded to pull dummy clients and outputs """
 UCTT_DUMMY_PROVISIONER_CONFIG_KEY_OUTPUTS = UCTT_OUTPUT_CONFIG_OUTPUTS_KEY
 """ What config key should be loaded to pull dummy outputs """
-UCTT_DUMMY_PROVISIONER_CONFIG_KEY_CLIENTS = UCTT_OUTPUT_CONFIG_CLIENTS_KEY
+UCTT_DUMMY_PROVISIONER_CONFIG_KEY_CLIENTS = UCTT_CLIENT_CONFIG_CLIENTS_KEY
 """ What config key should be loaded to pull dummy clients """
 
 

--- a/uctt/contrib/dummy/provisioner.py
+++ b/uctt/contrib/dummy/provisioner.py
@@ -23,7 +23,8 @@ UCTT_DUMMY_PROVISIONER_CONFIG_KEY_CLIENTS = 'clients'
 class DummyProvisionerPlugin(ProvisionerBase):
     """ Dummy provisioner class """
 
-    def prepare(self, label: str = UCTT_DUMMY_PROVISIONER_CONFIG_LABEL):
+    def prepare(
+            self, label: str = UCTT_DUMMY_PROVISIONER_CONFIG_LABEL, base: str = ''):
         """
 
         Interpret provided config and configure the object with outputs and
@@ -32,14 +33,21 @@ class DummyProvisionerPlugin(ProvisionerBase):
         """
         logger.info("{}:execute: prepare()".format(self.instance_id))
 
+        clients_key = '{}.{}'.format(
+            base,
+            UCTT_DUMMY_PROVISIONER_CONFIG_KEY_CLIENTS) if base else UCTT_DUMMY_PROVISIONER_CONFIG_KEY_CLIENTS
+        outputs_key = '{}.{}'.format(
+            base,
+            UCTT_DUMMY_PROVISIONER_CONFIG_KEY_OUTPUTS) if base else UCTT_DUMMY_PROVISIONER_CONFIG_KEY_OUTPUTS
+
         self.clients = uctt.new_clients_from_config(
             config=self.config,
-            label=UCTT_DUMMY_PROVISIONER_CONFIG_LABEL,
-            key=UCTT_DUMMY_PROVISIONER_CONFIG_KEY_CLIENTS)
+            label=label,
+            key=clients_key)
         self.outputs = uctt.new_outputs_from_config(
             config=self.config,
-            label=UCTT_DUMMY_PROVISIONER_CONFIG_LABEL,
-            key=UCTT_DUMMY_PROVISIONER_CONFIG_KEY_OUTPUTS)
+            label=label,
+            key=outputs_key)
 
     def apply(self):
         """ pretend to bring a cluster up """

--- a/uctt/contrib/kubernetes/client.py
+++ b/uctt/contrib/kubernetes/client.py
@@ -61,7 +61,7 @@ class KubernetesClientPlugin(ClientBase):
 
     """
 
-    def args(self, config_file: str):
+    def arguments(self, kube_config_file: str):
         """ set Kubernetes client args
 
         This implements the args part of the client interface.
@@ -78,9 +78,11 @@ class KubernetesClientPlugin(ClientBase):
         """
         logger.debug("Creating Kuberentes client from config file")
         self.api_client = kubernetes.config.new_client_from_config(
-            config_file=config_file)
+            config_file=kube_config_file)
 
     def get_CoreV1Api_client(self):
         """ Get a CoreV1Api client """
+        assert self.api_client, "You must run the arguments() method before using this client"
+
         logger.debug("Retrieving kubernetes CoreV1Api client from api_client")
         return kubernetes.client.CoreV1Api(self.api_client)

--- a/uctt/contrib/terraform/provisioner.py
+++ b/uctt/contrib/terraform/provisioner.py
@@ -1,6 +1,6 @@
 """
 
-Dummy MTT provisioner plugin
+Terraform UCTT provisioner plugin
 
 """
 
@@ -10,9 +10,12 @@ import os
 import subprocess
 from typing import Dict, List
 
+from configerus.loaded import LOADED_KEY_ROOT
 import uctt
-import uctt.plugins
+from uctt.output import UCTT_PLUGIN_TYPE_OUTPUT, UCTT_OUTPUT_CONFIG_OUTPUTS_KEY, OutputBase
+from uctt.instances import PluginInstances
 from uctt.provisioner import ProvisionerBase
+from uctt.contrib.common import UCTT_PLUGIN_ID_OUTPUT_DICT, UCTT_PLUGIN_ID_OUTPUT_TEXT
 
 logger = logging.getLogger('uctt.contrib.provisioner:terraform')
 
@@ -26,9 +29,9 @@ TERRAFORM_PROVISIONER_CONFIG_VARS_KEY = 'vars'
 """ config key for the terraform vars Dict, which will be written to a file """
 TERRAFORM_PROVISIONER_CONFIG_VARS_PATH_KEY = 'vars_path'
 """ config key for the terraform vars file path, where the plugin will write to """
-TERRAFORM_PROVISIONER_CONFIG_PATH_KEY = ''
+TERRAFORM_PROVISIONER_CONFIG_PATH_KEY = LOADED_KEY_ROOT
 """ config key for the terraform plan path """
-TERRAFORM_PROVISIONER_CONFIG_OUTPUTS_KEY = 'output'
+TERRAFORM_PROVISIONER_CONFIG_OUTPUTS_KEY = UCTT_OUTPUT_CONFIG_OUTPUTS_KEY
 """ config key for defining how to interpret the terraform outputs """
 TERRAFORM_PROVISIONER_DEFAULT_VARS_FILE = 'mtt_terraform.tfvars.json'
 """ Default vars file if none was specified """
@@ -71,7 +74,7 @@ class TerraformProvisionerPlugin(ProvisionerBase):
     """
 
     def prepare(self, label: str = TERRAFORM_PROVISIONER_CONFIG_LABEL,
-                base: str = ''):
+                base: str = LOADED_KEY_ROOT):
         """
 
         Interpret provided config and configure the object with all of the needed
@@ -82,7 +85,9 @@ class TerraformProvisionerPlugin(ProvisionerBase):
         logger.info("Preparing Terraform setting")
 
         self.terraform_config_label = label
+        """ configerus load label that should contain all of the config """
         self.terraform_config_base = base
+        """ configerus get key that should contain all tf config """
         self.terraform_config = self.config.load(self.terraform_config_label)
         """ get a configerus LoadedConfig for the terraform label """
 
@@ -96,7 +101,7 @@ class TerraformProvisionerPlugin(ProvisionerBase):
 
         state_path = self.terraform_config.get(
             TERRAFORM_PROVISIONER_CONFIG_STATE_PATH_KEY,
-            base=base,
+            base=self.terraform_config_base,
             exception_if_missing=False)
         """ terraform state path """
         if not state_path:
@@ -157,7 +162,20 @@ class TerraformProvisionerPlugin(ProvisionerBase):
 
     """ Cluster Interaction """
 
-    def get_outputs(self) -> uctt.plugin.PluginInstances:
+    def get_output(self, instance_id: str = '', plugin_id: str = '',
+                   exception_if_missing: bool = True) -> OutputBase:
+        """ retrieve an output from the provisioner """
+        outputs = self.get_outputs()
+        return outputs.get_plugin(
+            type=UCTT_PLUGIN_TYPE_OUTPUT, plugin_id=plugin_id, instance_id=instance_id)
+
+    def get_client(self, plugin_id: str = '', instance_id: str = '',
+                   exception_if_missing: bool = True):
+        """ make a client of the type, and optionally of the index """
+        raise NotImplementedError(
+            'This provisioner has not yet implemented get_client')
+
+    def get_outputs(self) -> PluginInstances:
         """ retrieve an output from terraform
 
         For other UCTT plugins we can just load configuration, but for output we
@@ -166,26 +184,60 @@ class TerraformProvisionerPlugin(ProvisionerBase):
         then we make some assumptions about plugin type and add it to the list.
 
         """
-        try:
-            outputs_key = '{}.{}'.format(
-                self.terraform_config_base,
-                TERRAFORM_PROVISIONER_CONFIG_OUTPUTS_KEY) if self.terraform_config_base else TERRAFORM_PROVISIONER_CONFIG_OUTPUTS_KEY
-            outputs = uctt.new_outputs_from_config(
-                self.config,
-                self.terraform_config_label,
-                outputs_key)
-        except BaseException:
-            outputs = uctt.plugin.PluginInstances()
 
-        for output_key, output_value in self.tf.output().items():
-            if not outputs.has_plugin(instance_id=output_key):
-                # we only know how to create 2 kinds of outputs
-                if isinstance(output_value, dict):
-                    output.add_plugin(TEXT, output_key).arguments(output_value)
+        # First make a set of output plugins config told us about (may be
+        # empty)
+        outputs_key = '{}.{}'.format(
+            self.terraform_config_base,
+            TERRAFORM_PROVISIONER_CONFIG_OUTPUTS_KEY) if not self.terraform_config_base == LOADED_KEY_ROOT else TERRAFORM_PROVISIONER_CONFIG_OUTPUTS_KEY
+        outputs = uctt.new_outputs_from_config(
+            config=self.config,
+            label=self.terraform_config_label,
+            base=outputs_key)
+
+        # now we ask TF what output it nows about and merge together those as
+        # new output plugins.
+        # tf.outputs() produces a list of (sensitive:bool, type: [str,  object,
+        # value:Any])
+        for output_key, output_struct in self.tf.output().items():
+            # we only know how to create 2 kinds of outputs
+            output_sensitive = output_struct['sensitive']
+            output_type = output_struct['type'][0]
+            output_spec = output_struct['type'][1]
+            output_value = output_struct['value']
+
+            # see if we already have an output plugin for this name
+            output_instance = outputs.get_plugin(
+                type=UCTT_PLUGIN_TYPE_OUTPUT,
+                instance_id=output_key,
+                exception_if_missing=False)
+            if not output_instance:
+                if output_type == 'object':
+                    plugin = outputs.add_plugin(
+                        type=UCTT_PLUGIN_TYPE_OUTPUT,
+                        plugin_id=UCTT_PLUGIN_ID_OUTPUT_DICT,
+                        instance_id=output_key,
+                        priority=80)
                 else:
-                    output.add_plugin(
-                        TEXT, output_key).arguments(
-                        str(output_value))
+                    plugin = outputs.add_plugin(
+                        type=UCTT_PLUGIN_TYPE_OUTPUT,
+                        plugin_id=UCTT_PLUGIN_ID_OUTPUT_TEXT,
+                        instance_id=output_key,
+                        priority=80)
+
+            if output_type == 'object':
+                plugin = outputs.add_plugin(
+                    type=UCTT_PLUGIN_TYPE_OUTPUT,
+                    plugin_id=UCTT_PLUGIN_ID_OUTPUT_DICT,
+                    instance_id=output_key,
+                    priority=80)
+                plugin.arguments(output_value)
+            else:
+                plugin = outputs.add_plugin(
+                    type=UCTT_PLUGIN_TYPE_OUTPUT,
+                    plugin_id=UCTT_PLUGIN_ID_OUTPUT_TEXT,
+                    instance_id=output_key,
+                    priority=80)
 
         return outputs
 

--- a/uctt/instances.py
+++ b/uctt/instances.py
@@ -37,7 +37,7 @@ class PluginInstances(configerus_PluginInstances):
 
         self.config = config
 
-    def copy(selfr):
+    def copy(self):
         """ Make a copy of this plugin list.
 
         This copies the instance list and by copying every plugin, overriding

--- a/uctt/output.py
+++ b/uctt/output.py
@@ -2,14 +2,21 @@ import logging
 
 from configerus.config import Config
 
-from .plugin import UCTTPlugin, Type
+from .plugin import UCCTArgumentsPlugin, Type
 
 logger = logging.getLogger('uctt.output')
 
-UCTT_PLUGIN_ID_OUTPUT = Type.OUTPUT
+UCTT_PLUGIN_TYPE_OUTPUT = Type.OUTPUT
 """ Fast access to the output plugin type """
 
+UCTT_OUTPUT_CONFIG_OUTPUTS_LABEL = 'outputs'
+""" A centralized configerus load label for multiple outputs """
+UCTT_OUTPUT_CONFIG_OUTPUTS_KEY = 'outputs'
+""" A centralized configerus key for multiple outputs """
+UCTT_OUTPUT_CONFIG_OUTPUT_KEY = 'output'
+""" A centralized configerus key for one output """
 
-class OutputBase(UCTTPlugin):
+
+class OutputBase(UCCTArgumentsPlugin):
     """ Base class for output plugins """
     pass

--- a/uctt/output.py
+++ b/uctt/output.py
@@ -11,6 +11,8 @@ UCTT_PLUGIN_TYPE_OUTPUT = Type.OUTPUT
 
 UCTT_OUTPUT_CONFIG_OUTPUTS_LABEL = 'outputs'
 """ A centralized configerus load label for multiple outputs """
+UCTT_OUTPUT_CONFIG_OUTPUT_LABEL = 'output'
+""" A centralized configerus load label for an output """
 UCTT_OUTPUT_CONFIG_OUTPUTS_KEY = 'outputs'
 """ A centralized configerus key for multiple outputs """
 UCTT_OUTPUT_CONFIG_OUTPUT_KEY = 'output'

--- a/uctt/plugin.py
+++ b/uctt/plugin.py
@@ -5,6 +5,22 @@ from configerus.config import Config
 
 logger = logging.getLogger('uctt.plugin')
 
+UCTT_PLUGIN_CONFIG_KEY_PLUGINID = 'plugin_id'
+""" configerus .get() key for plugin_id """
+UCTT_PLUGIN_CONFIG_KEY_INSTANCEID = 'instance_id'
+""" configerus .get() key for plugin_id """
+UCTT_PLUGIN_CONFIG_KEY_TYPE = 'type'
+""" configerus .get() key for plugin type """
+UCTT_PLUGIN_CONFIG_KEY_ARGUMENTS = 'arguments'
+""" configerus .get() key for plugin arguments """
+
+UCTT_PLUGIN_CONFIG_KEY_PRIORITY = 'priority'
+""" will use this Dict key assign an instance a priority when it is created. """
+UCTT_PLUGIN_CONFIG_KEY_CONFIG = 'config'
+""" will use this Dict key as additional config """
+UCTT_PLUGIN_CONFIG_KEY_VALIDATORS = 'validators'
+""" will use this Dict key from the output config to decide what validators to apply to the plugin """
+
 
 class UCTTPlugin():
     """ Base MTT Plugin which all plugins can extend """
@@ -21,6 +37,15 @@ class UCTTPlugin():
         """
         self.config = config
         self.instance_id = instance_id
+
+
+class UCCTArgumentsPlugin(UCTTPlugin):
+    """ Base class for output plugins that receives arguments """
+
+    def arguments(**kwargs):
+        """ Receive a list of arguments for this client """
+        raise NotImplemented(
+            'arguments() was not implemented for this client plugin')
 
 
 @unique

--- a/uctt/provisioner.py
+++ b/uctt/provisioner.py
@@ -15,6 +15,13 @@ logger = logging.getLogger('uctt.provisioner')
 UCTT_PLUGIN_TYPE_PROVISIONER = Type.PROVISIONER
 """ Fast access to the Provisioner plugin_id """
 
+UCTT_OUTPUT_CONFIG_PROVISIONERS_LABEL = 'provisioners'
+""" A centralized configerus load labe for multiple provisioners """
+UCTT_OUTPUT_CONFIG_PROVISIONERS_KEY = 'provisioners'
+""" A centralized configerus key for multiple provisioners """
+UCTT_OUTPUT_CONFIG_PROVISIONER_KEY = 'provisioner'
+""" A centralized configerus key for one provisioner """
+
 
 class ProvisionerBase(UCTTPlugin):
     "Base Provisioner plugin class"
@@ -34,20 +41,27 @@ class ProvisionerBase(UCTTPlugin):
         desired.
 
         """
-        pass
+        raise NotImplementedError(
+            'This provisioner has not yet implemented prepare')
 
     def apply(self):
         """ bring a cluster to the configured state """
-        pass
+        raise NotImplementedError(
+            'This provisioner has not yet implemented apply')
 
     def destroy(self):
         """ remove all resources created for the cluster """
-        pass
+        raise NotImplementedError(
+            'This provisioner has not yet implemented destroy')
 
-    def get_output(self, name: str):
+    def get_output(self, plugin_id: str = '', instance_id: str = '',
+                   exception_if_missing: bool = True):
         """ retrieve an output from the provisioner """
-        pass
+        raise NotImplementedError(
+            'This provisioner has not yet implemented get_output')
 
-    def get_client(self, type: str, index: str = ''):
+    def get_client(self, plugin_id: str = '', instance_id: str = '',
+                   exception_if_missing: bool = True):
         """ make a client of the type, and optionally of the index """
-        pass
+        raise NotImplementedError(
+            'This provisioner has not yet implemented get_client')

--- a/uctt/provisioner.py
+++ b/uctt/provisioner.py
@@ -15,11 +15,13 @@ logger = logging.getLogger('uctt.provisioner')
 UCTT_PLUGIN_TYPE_PROVISIONER = Type.PROVISIONER
 """ Fast access to the Provisioner plugin_id """
 
-UCTT_OUTPUT_CONFIG_PROVISIONERS_LABEL = 'provisioners'
+UCTT_PROVISIONER_CONFIG_PROVISIONERS_LABEL = 'provisioners'
 """ A centralized configerus load labe for multiple provisioners """
-UCTT_OUTPUT_CONFIG_PROVISIONERS_KEY = 'provisioners'
+UCTT_PROVISIONER_CONFIG_PROVISIONER_LABEL = 'provisioner'
+""" A centralized configerus load label a provisioner """
+UCTT_PROVISIONER_CONFIG_PROVISIONERS_KEY = 'provisioners'
 """ A centralized configerus key for multiple provisioners """
-UCTT_OUTPUT_CONFIG_PROVISIONER_KEY = 'provisioner'
+UCTT_PROVISIONER_CONFIG_PROVISIONER_KEY = 'provisioner'
 """ A centralized configerus key for one provisioner """
 
 

--- a/uctt/provisioner.py
+++ b/uctt/provisioner.py
@@ -19,8 +19,21 @@ UCTT_PLUGIN_TYPE_PROVISIONER = Type.PROVISIONER
 class ProvisionerBase(UCTTPlugin):
     "Base Provisioner plugin class"
 
-    def prepare(self):
-        """ Prepare the provisioner to apply resources """
+    def prepare(self, label: str = '', base: str = ''):
+        """ Prepare the provisioner to apply resources
+
+        Initial Provisioner plugin is expected to be of very low cost until
+        prepare() is executed.  At this point the plugin should load any config
+        and perform any validations needed.
+        The plugin should not create any resources but it is understood that
+        there may be a cost of preparation.
+
+        Provisioners are expected to load a lot of config to self-program.
+        Because of this, they allow passing of a configerus label for .load()
+        and a base for .get() in case there is an alterante config source
+        desired.
+
+        """
         pass
 
     def apply(self):

--- a/uctt/test/test_dummy.py
+++ b/uctt/test/test_dummy.py
@@ -132,6 +132,16 @@ class ConfigTemplating(unittest.TestCase):
         provisioner = self._dummy_provisioner()
         self.assertIsInstance(provisioner, DummyProvisionerPlugin)
 
+    def test_workloads_sanity(self):
+        """ test that we can load the workloads """
+        workloads = self._dummy_workloads()
+
+        workload_one = workloads.get_plugin(instance_id='one')
+        self.assertIsInstance(workload_one, DummyWorkloadPlugin)
+
+        with self.assertRaises(KeyError):
+            workloads['does.not.exist']
+
     def test_provisioner_workflow(self):
         """ test that the provisioner can follow a decent workflow """
         provisioner = self._dummy_provisioner()
@@ -142,16 +152,6 @@ class ConfigTemplating(unittest.TestCase):
         # ...
 
         provisioner.destroy()
-
-    def test_workloads_sanity(self):
-        """ test that we can load the workloads """
-        workloads = self._dummy_workloads()
-
-        workload_one = workloads.get_plugin(instance_id='one')
-        self.assertIsInstance(workload_one, DummyWorkloadPlugin)
-
-        with self.assertRaises(KeyError):
-            workloads['does.not.exist']
 
     def test_workloads_outputs(self):
         """ test that the dummy workload got its outputs from configuration """

--- a/uctt/workload.py
+++ b/uctt/workload.py
@@ -2,18 +2,21 @@ import logging
 
 from configerus.config import Config
 
-from .plugin import UCTTPlugin, Type
+from .plugin import UCCTArgumentsPlugin, Type
 
 logger = logging.getLogger('uctt.workload')
 
 UCTT_PLUGIN_ID_WORKLOAD = Type.WORKLOAD
 """ Fast access to the workload type """
 
+UCTT_OUTPUT_CONFIG_WORKLOADS_LABEL = 'workloads'
+""" A centralized configerus load label for multiple workloads """
+UCTT_OUTPUT_CONFIG_WORKLOADS_KEY = 'workloads'
+""" A centralized configerus key for multiple workloads """
+UCTT_OUTPUT_CONFIG_WORKLOAD_KEY = 'workload'
+""" A centralized configerus key for one workload """
 
-class WorkloadBase(UCTTPlugin):
+
+class WorkloadBase(UCCTArgumentsPlugin):
     """ Base class for workload plugins """
-
-    def arguments(**kwargs):
-        """ Receive a list of arguments for this workload """
-        raise NotImplemented(
-            'arguments() was not implemented for this workload plugin')
+    pass

--- a/uctt/workload.py
+++ b/uctt/workload.py
@@ -9,11 +9,13 @@ logger = logging.getLogger('uctt.workload')
 UCTT_PLUGIN_ID_WORKLOAD = Type.WORKLOAD
 """ Fast access to the workload type """
 
-UCTT_OUTPUT_CONFIG_WORKLOADS_LABEL = 'workloads'
+UCTT_WORKLOAD_CONFIG_WORKLOADS_LABEL = 'workloads'
 """ A centralized configerus load label for multiple workloads """
-UCTT_OUTPUT_CONFIG_WORKLOADS_KEY = 'workloads'
+UCTT_WORKLOAD_CONFIG_WORKLOAD_LABEL = 'workload'
+""" A centralized configerus load label for a workload """
+UCTT_WORKLOAD_CONFIG_WORKLOADS_KEY = 'workloads'
 """ A centralized configerus key for multiple workloads """
-UCTT_OUTPUT_CONFIG_WORKLOAD_KEY = 'workload'
+UCTT_WORKLOAD_CONFIG_WORKLOAD_KEY = 'workload'
 """ A centralized configerus key for one workload """
 
 


### PR DESCRIPTION
- provisioners now generally accept config label and key base overrides in prepare()
- dict output handler is a bit cleaner
- a few more log debug messaged in provisioner construction
- centralized module contstants for configerus labels and default keys (was getting hard to keep synched)
- moved configerus to 0.3.0 for better key merging
- version bump

Signed-off-by: James Nesbitt <jnesbitt@mirantis.com>