### PR TITLE
fix empty environment list check

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = uctt
-version = 0.5.1
+version = 0.5.2
 description = Universal cluster testing toolkit
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/uctt/__init__.py
+++ b/uctt/__init__.py
@@ -123,8 +123,6 @@ def new_environment_from_config(config: Config,
 
 def environment_names() -> List[str]:
     """ Return a list of all of the created environments """
-    if len(_environments) == 0:
-        raise ValueError("No environments have been configured yet.")
     return list(_environments)
 
 

--- a/uctt/contrib/terraform/provisioner.py
+++ b/uctt/contrib/terraform/provisioner.py
@@ -96,7 +96,7 @@ class TerraformProvisionerPlugin(ProvisionerBase, UCCTFixturesPlugin):
         """ get a configerus LoadedConfig for the terraform label """
 
         self.root_path = self.terraform_config.get([self.terraform_config_base, TERRAFORM_PROVISIONER_CONFIG_ROOT_PATH_KEY],
-                                                     exception_if_missing=False)
+                                                   exception_if_missing=False)
         """ all relative paths will have this joined as their base """
 
         self.working_dir = self.terraform_config.get([self.terraform_config_base, TERRAFORM_PROVISIONER_CONFIG_PLAN_PATH_KEY],
@@ -107,7 +107,8 @@ class TerraformProvisionerPlugin(ProvisionerBase, UCCTFixturesPlugin):
                 "Plugin config did not give us a working/plan path: {}".format(self.terraform_config.data))
         if not os.path.isabs(self.working_dir):
             if self.root_path:
-                self.working_dir = os.path.join(self.root_path, self.working_dir)
+                self.working_dir = os.path.join(
+                    self.root_path, self.working_dir)
             self.working_dir = os.path.abspath(self.working_dir)
 
         state_path = self.terraform_config.get([self.terraform_config_base, TERRAFORM_PROVISIONER_CONFIG_STATE_PATH_KEY],

--- a/uctt/plugin.py
+++ b/uctt/plugin.py
@@ -92,7 +92,8 @@ class Type(Enum):
 
         """
         if type is None:
-            raise ValueError("Cannot determine type of plugin sa you passed a None value")
+            raise ValueError(
+                "Cannot determine type of plugin sa you passed a None value")
 
         try:
             return Type(type_string)


### PR DESCRIPTION
- before an exception was raised if you check if an environment exists
when none was created (fixes tests)
- also some autopep8

Signed-off-by: James Nesbitt <jnesbitt@mirantis.com>